### PR TITLE
fix(detail): Crews and Casters Content Not Constraint to The Top of Screen

### DIFF
--- a/detail/ui/src/main/java/com/arj/detail/ui/tab/caster/DetailMovieCasterUI.kt
+++ b/detail/ui/src/main/java/com/arj/detail/ui/tab/caster/DetailMovieCasterUI.kt
@@ -1,6 +1,7 @@
 package com.arj.detail.ui.tab.caster
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -37,6 +38,7 @@ internal fun CastUI(
 ) {
     LazyColumn(
         modifier = Modifier.padding(8.dp)
+            .fillMaxSize()
     ) {
         items(casts.size) { index ->
             val cast = casts[index]

--- a/detail/ui/src/main/java/com/arj/detail/ui/tab/crew/DetailMovieCrewUI.kt
+++ b/detail/ui/src/main/java/com/arj/detail/ui/tab/crew/DetailMovieCrewUI.kt
@@ -1,6 +1,7 @@
 package com.arj.detail.ui.tab.crew
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -37,6 +38,7 @@ internal fun CrewUI(
 ) {
     LazyColumn(
         modifier = Modifier.padding(8.dp)
+            .fillMaxSize()
     ) {
         items(crews.size) { index ->
             val crew = crews[index]


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/e551d5ba-6b3f-401e-a21b-0d8be993d1b5" height="460" width="210"/> | <img src="https://github.com/user-attachments/assets/a7d68869-9bdf-4ecb-be18-eb4fedc0f5f3" height="460" width="210"/> |
| <img src="https://github.com/user-attachments/assets/4db5819c-6cef-4fca-8548-66eecc289050" height="460" width="210"/> | <img src="https://github.com/user-attachments/assets/2537a60e-0961-4621-abca-feff72745dc1" height="460" width="210"/> | 